### PR TITLE
Fix speed limit offset

### DIFF
--- a/opendbc/car/rivian/carstate.py
+++ b/opendbc/car/rivian/carstate.py
@@ -82,7 +82,7 @@ class CarState(CarStateBase):
     # (approximately +/- ~20MPH) of the current vehicle speed to avoid false positives.
     if self.sign_speed != current_sign_speed and abs(self.set_speed - current_sign_speed) <= 9:
       offset = int(Params().get("TrafficSignOffset"))
-      self.sign_offset = offset + ((5 * offset) / 100)
+      self.sign_offset = 1 + ((5 * offset) / 100)
       if self.sign_offset != 0:
        self.set_speed = current_sign_speed * self.sign_offset
     self.sign_speed = current_sign_speed


### PR DESCRIPTION
Fix speed limit offset calculation. Previously if offset was 2 (10%), the calculation would have been:

2 + ((5*2)/100) = 2.1
Then if sign speed was 45mph, the set speed would be 95.5mph.

By removing the first offset variable and making it 1, the calculation is 1 + ((5*2)/100) = 1.1. Then if sign speed was 45mph, the set speed would be 49.5mph.